### PR TITLE
Fix getDERfromPEM in Ubuntu 22.04

### DIFF
--- a/hash-bash-ssl.sh
+++ b/hash-bash-ssl.sh
@@ -95,7 +95,7 @@ function canonicalizeDN() {
 
 # Function to turn PEM into DER
 function getDERfromPEM () { #Returns HEX encoded DER of first PEM Certificate in file 
-  awk '/^-----BEGIN CERTIFICATE-----$/ {i=1} /^[A-Za-z0-9\/+=]+\r?$/ { if(i) print } /-----END CERTIFICATE-----/ {exit }' |tr -d '\r\n' |base64 -d |od -An -v -w0 -tx1 2>/dev/null |grep '^[0-9a-f ]*$' |tr -d "\n "
+  awk '/^-----BEGIN CERTIFICATE-----[\r|\n]*$/ {i=1} /^[A-Za-z0-9\/+=]+[\r|\n]*$/ { if(i) print } /-----END CERTIFICATE-----/ {exit }' |tr -d '\r\n' |base64 -d |od -An -v -w0 -tx1 2>/dev/null |grep '^[0-9a-f ]*$' |tr -d "\n "
 }
 
 declare -a PEMS


### PR DESCRIPTION
I get a wrong hash in Ubuntu 22.04. I suspect that the regular expression of awk in `getDERfromPEM` caused this problem.  
Without the `[\r|\n]*`, awk will never set i=1. As a result, awk will always output an empty string, the downstream functions will process an empty string and finally output a wrong hash (of course the hash of an empty string is not the hash of the certificate).  
I don't know whether #17 is related to `getDERfromPEM` and I hope this commit can fix it.